### PR TITLE
Fix IPv6 support for Web UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV GUI_USER=${GUI_USER:-admin}
 ENV GUI_PASSWORD=${GUI_PASSWORD:-difficult}
 ENV GUI_PORT=${GUI_PORT:-10000}
 
-RUN apk update && apk upgrade && apk add --no-cache tzdata supervisor bind bind-tools perl perl-net-ssleay && \
+RUN apk update && apk upgrade && apk add --no-cache tzdata supervisor bind bind-tools perl perl-net-ssleay perl-socket6 && \
     wget -q http://prdownloads.sourceforge.net/webadmin/webmin-${WEBMIN_VER}.tar.gz -O /opt/webmin.tar.gz && \
     tar xf /opt/webmin.tar.gz -C /opt && \
     rm -rf /opt/webmin.tar.gz && \


### PR DESCRIPTION
I'm using the container pwa666/bind9 from DockerHub in its latest version (v1.3.101).

I have set the variable `IPV6` to `enable`, and DNS queries do work over IPv6. The GUI, however, doesn't. By default it just listens on 0.0.0.0 instead of [::], and when I try to change that in the GUI (Webmin -> Webmin Configuration -> Ports and Addresses -> Accept IPv6 connections) , I get the error message `IPv6 cannot be enabled unless the Socket6 Perl module is installed`. 

With this change (installing the perl-socket6 package while building the container) IPv6 support works and the WebUI listens on IPv6 as well. 

(Also, is there any plans to update the container base at some point? I see a new version on Docker Hub once a week or so, but I'm not sure what's changed in these since the container is still using webmin 1.984 (from 2021) and Alpine 3.15 (also from 2021)).