### PR TITLE
ci: add manual RC workflow (rc.yml), GHCR-only amd64

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -1,0 +1,48 @@
+name: Build and publish RC image (GHCR only)
+
+on:
+  workflow_dispatch:        # manual trigger only (UI button + API)
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: vrx-666/bind9
+
+jobs:
+  build:
+    if: github.repository == 'vrx-666/bind9'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write   # required to push to GHCR
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Auth GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # RC is amd64-only (fast iteration; the test-environment runs on amd64) and
+      # publishes ONLY to GHCR under the moving :rc tag - never Docker Hub, never
+      # :stable. No version is computed on purpose: RC images are throwaway test
+      # candidates, so they carry LABEL version=rc instead of a release number.
+      # The real version is computed only by stable.yml on push to master, so RC
+      # builds never touch the stable release numbering.
+      - name: Build and push RC (GHCR only, amd64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          build-args: |
+            VERSION=rc
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rc
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## What
Add a manual release-candidate workflow `rc.yml`, analogous to `bacula-server`'s.

## Behavior
- Trigger: `workflow_dispatch` only (manual — UI button / `gh workflow run`).
- Builds **amd64-only** and pushes **GHCR-only** under the moving `:rc` tag — never Docker Hub, never `:stable`.
- Guarded by `if: github.repository == 'vrx-666/bind9'`.
- **No version is computed**: RC images are throwaway test candidates, so they carry `LABEL version=rc`. The real release number stays owned by `stable.yml` (push to master), so RC never affects the stable numbering. This also drops the `fetch-depth: 0` / version-compute step.

## Why
Gives bind9 the same three-stage pipeline as `bacula-server` (PR → RC → stable). The RC image is meant to feed a future `test-environment/` that pulls `ghcr.io/vrx-666/bind9:rc` to validate a candidate before promoting it to stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzrsbc8pMkckejr673ZFBa