### PR TITLE
chore: gitignore CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config
 docker-compose.yml
 bind8-lib.pl.bckp
+CLAUDE.md


### PR DESCRIPTION
`repo/CLAUDE.md` is a local-only working note (per its own header and the workspace convention), so it must never be tracked. Right now it is untracked but **not** ignored on `master`, so it could be committed by accident. This adds `CLAUDE.md` to `.gitignore` to prevent that.

One-line change to `.gitignore`; no code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzrsbc8pMkckejr673ZFBa