### PR TITLE
ci: skip stable build for CI/docs-only changes

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -3,6 +3,14 @@ on:
   push:
     branches:
       - master
+    # Don't rebuild+republish stable for changes that never affect the image
+    # (CI workflows, gitignore, docs). A push is skipped only when ALL of its
+    # changed files match these globs, so a Dockerfile/VERSION change still
+    # triggers a release.
+    paths-ignore:
+      - '.github/**'
+      - '.gitignore'
+      - 'README.md'
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: vrx-666/bind9


### PR DESCRIPTION
Adds `paths-ignore` to `stable.yml` so a push to `master` that only touches CI workflows, `.gitignore`, or `README.md` does **not** rebuild and republish the stable image (GHCR + Docker Hub) or bump the version.

A push still triggers a release when `Dockerfile` or `VERSION` change — `paths-ignore` skips a push only when **all** changed files match the globs.

This decouples CI/hygiene merges from stable releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzrsbc8pMkckejr673ZFBa